### PR TITLE
#166964798 Build endpoint for properties with same type

### DIFF
--- a/src/routes/property-advert.routes.js
+++ b/src/routes/property-advert.routes.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const propertyrouter = express.Router();
 import {multerUploads} from '../middlewares/multer';
+import url from 'url';
 
 import {cloudinaryHandler} from '../middlewares/cloudinary';
-const propertyadvert = require('../models/property-advert.model');
-import {authorization,getId,getPreviousId,idCheck,toDeleteId} from '../middlewares/auth/auth';
+import {getPropertyAdvert,getPropertyAdverts,updatePropertyAdvert,deletePropertyAdvert,insertPropertyAdvert,getTypeProperty} from '../models/property-advert.model';
+import {authorization,getId,getPreviousId,idCheck,toDeleteId,getSingleIdProperty} from '../middlewares/auth/auth';
 import {jwtVerify} from '../middlewares/auth/jsonweb';
 import {checkPropertyEmpty,checkPropertyField} from '../middlewares/field/inputfield';
 
@@ -14,28 +15,43 @@ import {checkPropertyEmpty,checkPropertyField} from '../middlewares/field/inputf
 propertyrouter.post('/property-advert', authorization, 
 	jwtVerify,multerUploads,checkPropertyEmpty,checkPropertyField,cloudinaryHandler, getId,async(req, res)=>{
 		const {data} = req;
-		propertyadvert.insertPropertyAdvert(data)
+		insertPropertyAdvert(data)
 			.then(response=>{
 				res.status(200).json({status:200,data:response});
 			});
   
 	});
 
+
 propertyrouter.patch('/property-advert/:id', idCheck, authorization, 
 	jwtVerify,multerUploads,checkPropertyEmpty,checkPropertyField,cloudinaryHandler, getPreviousId,async(req, res)=>{
 		const {data} = req;
 		const id = req.params.id;	
-		propertyadvert.updatePropertyAdvert(id,data)
+		updatePropertyAdvert(id,data)
 			.then(response=>{
 				res.status(200).json({status:200,data:response});
 			}).catch(err=>res.status(404).json({status: 404, err: err.message}));
 			
 	});
 
+
+propertyrouter.patch('/property-advert/:id/sold', idCheck, authorization, jwtVerify, getSingleIdProperty,async(req, res)=>{	
+	const {data} = req;
+	const id = req.params.id;	
+	updatePropertyAdvert(id,data)
+		.then(response=>{
+			res.status(200).json({status:200,data:response});
+		}).catch(err=>res.status(404).json({status: 404, err: err.message}));
+			
+});
+
+
+	
+
 propertyrouter.delete('/property-advert/:id', idCheck, authorization, 
 	jwtVerify, toDeleteId,async(req, res)=>{
 		const id = req.params.id;	
-		propertyadvert.deletePropertyAdvert(id)
+		deletePropertyAdvert(id)
 			// eslint-disable-next-line no-unused-vars
 			.then(response=>{
 				res.status(201).json({status:200,data:{message:`advert with the ${id} id has been successfully deleted`}});
@@ -44,18 +60,30 @@ propertyrouter.delete('/property-advert/:id', idCheck, authorization,
 	});
 
 propertyrouter.get('/property-advert/',async(req, res)=>{
-	propertyadvert.getPropertyAdverts()
+	
+	getPropertyAdverts()
 		.then(response=>{
 			res.status(201).json({status:200,data:response});
 		}).catch(err=>res.status(404).json({status: 404, err: err.message}));
 			
 });
 
-propertyrouter.get('/property-advert/?q',async(req, res)=>{
-	propertyadvert.getPropertyAdverts()
+propertyrouter.get('/property-advert/search',async(req, res)=>{
+	const url_parts = url.parse(req.url,true).query;
+	getTypeProperty(url_parts.type)
+		.then(response=>{
+			res.status(201).json({status:200,data:response});
+		}).catch(err=>res.status(404).json({status: 404, err: err.err}));
+		
+			
+});
+
+propertyrouter.get('/property-advert/:id',async(req, res)=>{
+	getPropertyAdvert(req.params.id)
 		.then(response=>{
 			res.status(201).json({status:200,data:response});
 		}).catch(err=>res.status(404).json({status: 404, err: err.message}));
+		
 			
 });
 

--- a/src/routes/property-advert.routes.js
+++ b/src/routes/property-advert.routes.js
@@ -44,12 +44,20 @@ propertyrouter.delete('/property-advert/:id', idCheck, authorization,
 	});
 
 propertyrouter.get('/property-advert/',async(req, res)=>{
-		propertyadvert.getPropertyAdverts()
-			.then(response=>{
-				res.status(201).json({status:200,data:response});
-			}).catch(err=>res.status(404).json({status: 404, err: err.message}));
+	propertyadvert.getPropertyAdverts()
+		.then(response=>{
+			res.status(201).json({status:200,data:response});
+		}).catch(err=>res.status(404).json({status: 404, err: err.message}));
 			
-	});
+});
+
+propertyrouter.get('/property-advert/?q',async(req, res)=>{
+	propertyadvert.getPropertyAdverts()
+		.then(response=>{
+			res.status(201).json({status:200,data:response});
+		}).catch(err=>res.status(404).json({status: 404, err: err.message}));
+			
+});
 
 
 


### PR DESCRIPTION
***What does this PR do?***
It builds the endpoint for properties with same type

**Description of Task to be completed?**
none

**How should this be manually tested?**
clone this branch and run ```npm install``` ```npm start```  and check postman at the url ```http://localhost:3300/api/v1/property-advert/search``` with the required input field from the pivotal stories
**Any background context you want to provide?**
None

**What are the relevant pivotal tracker stories?**
As user   
I can view all properties of a specific property category (type)

### Acceptance Criteria

-   Given user 
-   When user sends a GET 
    `GET /api/v1/property-advert/search`
-   Then all property with similar type in memory is viewed
-   And a  **201 Created**  response is returned
-   When user see the  **201 Created**  response
-   Then user see the body described in the property object below



Response:

```json
{   
  “status” ​ :​ ​ Integer​ ,  
 ​ “data” ​ :​ ​ [
    {  “id” ​ :​ ​ Integer​ ,   
  “status” ​ :​ ​ String​ ,    
 ​ “type” ​ :​ ​ String​ ,    
 ​ “state” ​ :​ ​ String​ ,   
  “city” ​ :​ ​ String​ ,  
   “address” ​ :​ ​ String​ ,   
  “price” ​ :​ ​ Float​ ,   
    “created_on” ​ :​ ​ DateTime​ ,  
   “image_url” ​ :​ ​ String​ ,    
 ​ “ownerEmail” ​ :​ ​ String​ ,  
   “ownerPhoneNumber” ​ :​ ​ String​ , 
    ...   ​ }, 
{     
​ “id” ​ :​ ​ Integer​ ,  
   “status” ​ :​ ​ String​ ,  
   ​ “type” ​ :​ ​ String​ ,    
 ​ “state” ​ :​ ​ String​ ,  
   “city” ​ :​ ​ String​ ,  
   “address” ​ :​ ​ String​ ,   
  “price” ​ :​ ​ Float​ ,   
    “created_on” ​ :​ ​ DateTime​ ,  
   “image_url” ​ :​ ​ String​ ,  
   “ownerEmail” ​ :​ ​ String​ , 
    “ownerPhoneNumber” ​ :​ ​ String​ ,  
   ...   ​ }
]  
 } 

```
Screenshots (if appropriate)