### PR TITLE
feature(single-property-postgres):add route to view single property a…

### DIFF
--- a/db.js
+++ b/db.js
@@ -25,14 +25,15 @@ const createPropertyTable = () => {
         status TEXT NOT NULL,
         state TEXT NOT NULL,
 		city TEXT NOT NULL,
+		type VARCHAR(120) NOT NULL,
 		price int NOT NULL,
 		contact_person_number VARCHAR(13) NOT NULL,
 		contact_person_address TEXT NOT NULL,
 		proof BOOLEAN NOT NULL,
 		note TEXT NOT NULL,
+		image TEXT NOT NULL,
         created_date TIMESTAMP,
 		modified_date TIMESTAMP,
-		image TEXT NOT NULL,
         FOREIGN KEY (owner_id) REFERENCES users (id) ON DELETE CASCADE
 	  )`;
 	pool.query(queryText)

--- a/src/usingDb/controller/property.js
+++ b/src/usingDb/controller/property.js
@@ -13,25 +13,27 @@ import uuidv4 from 'uuid/v4';
 
 
 const createProperty = async(req, res) => { 
-	const {property_name, status,state,city, price,contact_person_number,contact_person_address, proof,note,} = req.body;
+	const {property_name, status,state,city, price,contact_person_number,contact_person_address, proof,note,type} = req.body;
 	const createQuery = `INSERT INTO property(owner_id,
-		property_name, status,state,city, price,contact_person_number,
-		contact_person_address, proof,note, created_date, modified_date,image)
-      VALUES($1, $2, $3, $4, $5, $6, $7,$8,$9,$10,$11,$12,$13) returning *`;
+		property_name, status,state,city,type, price,contact_person_number,
+		contact_person_address, proof,note,image,created_date, modified_date)
+      VALUES($1, $2, $3, $4, $5, $6, $7,$8,$9,$10,$11,$12,$13,$14) returning *`;
 	const values = [
 		req.result.userId,
 		property_name,
 		status,
 		state,
 		city,
+		type,
 		price,
 		contact_person_number,
 		contact_person_address, 
 		proof,
 		note,
-		moment(new Date()),
-		moment(new Date()),
 		req.Image_url,
+		moment(new Date()),
+		moment(new Date()),
+		
 	];
 	
 	try {
@@ -53,7 +55,7 @@ const createProperty = async(req, res) => {
   
 const getAllProperty = async (req, res) => { 
 	const findAllQuery = `SELECT id,property_name,status,state,city,price,
-	contact_person_number,contact_person_address,proof,created_date,image
+	contact_person_number,contact_person_address,proof,type,created_date,image
 	 FROM property`;
 	try {
 		const { rows, rowCount } = await query(findAllQuery);
@@ -91,9 +93,11 @@ const getAllPropertyOfUser = async (req, res) => {
 
 const getOneProperty = async (req, res) => { 
 	
-	const text = 'SELECT * FROM property WHERE id = $1 AND owner_id = $2';
+	const text = `SELECT id,property_name,status,state,city,price,
+	contact_person_number,contact_person_address,proof,type,created_date,image
+	 FROM property WHERE id = $1`;
 	try {
-		const { rows } = await query(text, [req.params.id, req.result.userId]);
+		const { rows } = await query(text, [req.params.id]);
 		if (!rows[0]) {
 			return res.status(404).send({'message': 'reflection not found'});
 		}

--- a/swagger.json
+++ b/swagger.json
@@ -7,10 +7,10 @@
   },
   "servers": [
     {
-      "url": "https://propertpro-lite.herokuapp.com/"
+      "url": "https://propertpro-lite.herokuapp.com/api/v1/"
     },
     {
-      "url": "http://localhost:3300/"
+      "url": "http://localhost:3300/api/v1/"
     }
   ],
   "tags": [
@@ -48,7 +48,7 @@
         }
       }
     },
-    "/api/v1/auth/register": {
+    "/auth/register": {
       "post": {
         "tags": [
           "Users"
@@ -121,7 +121,7 @@
         }
       }
     },
-    "/api/v1/auth/login": {
+    "/auth/login": {
       "post": {
         "tags": [
           "Users"
@@ -179,7 +179,7 @@
         }
       }
     },
-    "/api/v1/property-advert": {
+    "/property-advert": {
       "get": {
         "tags": [
           "Properties"
@@ -301,7 +301,7 @@
         }
       }
     },
-    "/api/v1/property-advert/{propertyId}": {
+    "/property-advert/{propertyId}": {
       "get": {
         "tags": [
           "Properties"
@@ -509,7 +509,7 @@
         }
       }
     },
-    "/api/v1/property-advert/{propertyId}/sold": {
+    "/property-advert/{propertyId}/sold": {
       "patch": {
         "tags": [
           "Properties"
@@ -590,7 +590,7 @@
         }
       }
     },
-    "/api/v1/property-advert/search/": {
+    "/property-advert/search/": {
       "get": {
         "tags": [
           "Properties"


### PR DESCRIPTION
#### What does this PR do?
it get single property advert in postgres database
#### Description of Task to be completed?
code refactoring
#### How should this be manually tested?
clone this branch run ```npm i``` and ```npm run dev``` and go to ```http:localhost:3300/api/v1/property-advert/<property-id>``` with a get verb
#### Any background context you want to provide?
none
#### What are the relevant pivotal tracker stories?
[#167141898](https://www.pivotaltracker.com/n/projects/2354433)
#### Screenshots (if appropriate)

#### Questions:67141898]